### PR TITLE
Add the Rust implementation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,3 +8,6 @@
 [submodule "js"]
 	path = js
 	url = https://github.com/SWAN-community/owid-js.git
+[submodule "rust"]
+	path = rust
+	url = https://github.com/SWAN-community/owid-rust.git

--- a/explainer.md
+++ b/explainer.md
@@ -27,6 +27,7 @@ Concrete implementations of OWID are available in the following repositories.
 -   [.NET](https://github.com/SWAN-community/owid-dotnet) (version 5+)
 -   [Go](https://github.com/SWAN-community/owid-go)
 -   [JavaScript](https://github.com/SWAN-community/owid-js) (verify only)
+-   [Rust](https://github.com/SWAN-community/owid-rust)
 
 ## Pre-requisites
 


### PR DESCRIPTION
* Adds owid-rust as the rust submodule pinned to its current main.
* Lists the Rust implementation alongside the others in the explainer.